### PR TITLE
Fix obtaining display ID up untill android 12L at least - fix #1

### DIFF
--- a/startscreen.ps1
+++ b/startscreen.ps1
@@ -78,7 +78,7 @@ function target_sanity_check {
 	}
 
 	# Check if all the executables are present on the target device
-	$BINlist = "sh,ps,grep"
+	$BINlist = "sh,ps,grep,cut,sort,uniq,head"
 	$BINlist = $BINlist.split(",");
 	foreach ($i in $BINlist) {
 		$output = [string](& $PATHS.adb shell "which $i")
@@ -165,8 +165,10 @@ $TARGET_DISPLAY_MODE = "$RESOLUTION`/$DENSITY"
 # Wait for the display to appear
 Start-Sleep 1
 
-# Do your magic
-$display_fetch_cmd = 'dumpsys display | grep \"  Display \" | cut -d\" \" -f4 | grep -v "0:" | sed -e \"s/://\"'
+# Should work up untill android 12L (13 untested) 
+# Selects the first of found displays (todo add option to select manually if there is more than one external display 
+# so 3 in total because we ommit id=0 as it's the main display that doesn't show dektop mode - at least yet)
+$display_fetch_cmd = 'dumpsys display|grep mDisplayId=|cut -d \"=\" -f2|sort|uniq|grep -v 0|head -n1'
 $display = [string](& $PATHS.adb shell "$display_fetch_cmd")
 
 ## if fetching fails, try defaults

--- a/startscreen.ps1
+++ b/startscreen.ps1
@@ -168,7 +168,7 @@ Start-Sleep 1
 # Should work up untill android 12L (13 untested) 
 # Selects the first of found displays (todo add option to select manually if there is more than one external display 
 # so 3 in total because we ommit id=0 as it's the main display that doesn't show dektop mode - at least yet)
-$display_fetch_cmd = 'dumpsys display|grep mDisplayId=|cut -d \"=\" -f2|sort|uniq|grep -v 0|head -n1'
+$display_fetch_cmd = 'dumpsys display|grep mDisplayId=|cut -d \"=\" -f2|sort -n|uniq|grep -v \"^0$\"|head -n1'
 $display = [string](& $PATHS.adb shell "$display_fetch_cmd")
 
 ## if fetching fails, try defaults

--- a/startscreen.sh
+++ b/startscreen.sh
@@ -49,7 +49,7 @@ function target_sanity_check {
 		exit 1
 
 	# Check if all the executables are present on the target device
-	for i in sh ps grep; do
+	for i in sh ps grep cut sort uniq head; do
 		adb shell which $i >/dev/null 2>&1
 		[[ $? -ne 0 ]] && \
 			echo "Your Android device is missing '$i' and this script won't work without it. Sorry..." && \
@@ -142,8 +142,10 @@ adb shell settings put global overlay_display_devices $TARGET_DISPLAY_MODE
 # Wait for the display to appear
 sleep 1
 
-# Do your magic
-display=$(adb shell dumpsys display | grep "  Display " | cut -d' ' -f4 | grep -v "0:" | sed -e 's/://')
+# Should work up untill android 12L (13 untested) 
+# Selects the first of found displays (todo add option to select manually if there is more than one external display 
+# so 3 in total because we ommit id=0 as it's the main display that doesn't show dektop mode - at least yet)
+display=$(adb shell 'dumpsys display|grep mDisplayId=|cut -d "=" -f2|sort|uniq|grep -v 0|head -n1')
 
 # if fetching fails, try defaults
 if [ "$display" = "" ]; then
@@ -159,7 +161,7 @@ if [ "$display" = "" ]; then
 	sleep 1
 
 	# Do your magic
-	display=$(adb shell dumpsys display | grep "  Display " | cut -d' ' -f4 | grep -v "0:" | sed -e 's/://')
+	display=$(adb shell 'dumpsys display|grep mDisplayId=|cut -d "=" -f2|sort|uniq|grep -v 0|head -n1')
 fi
 
 # use -S if you're edgy

--- a/startscreen.sh
+++ b/startscreen.sh
@@ -145,7 +145,7 @@ sleep 1
 # Should work up untill android 12L (13 untested) 
 # Selects the first of found displays (todo add option to select manually if there is more than one external display 
 # so 3 in total because we ommit id=0 as it's the main display that doesn't show dektop mode - at least yet)
-display=$(adb shell 'dumpsys display|grep mDisplayId=|cut -d "=" -f2|sort|uniq|grep -v 0|head -n1')
+display=$(adb shell 'dumpsys display|grep mDisplayId=|cut -d "=" -f2|sort -n|uniq|grep -v "^0$"|head -n1')
 
 # if fetching fails, try defaults
 if [ "$display" = "" ]; then
@@ -161,7 +161,7 @@ if [ "$display" = "" ]; then
 	sleep 1
 
 	# Do your magic
-	display=$(adb shell 'dumpsys display|grep mDisplayId=|cut -d "=" -f2|sort|uniq|grep -v 0|head -n1')
+	display=$(adb shell 'dumpsys display|grep mDisplayId=|cut -d "=" -f2|sort -n|uniq|grep -v "^0$"|head -n1')
 fi
 
 # use -S if you're edgy


### PR DESCRIPTION
Hi again.
I tested it with Android Studio EE Desktop image emulator (12L) on windows 10.
Please make sure it works for you and check if I didn't update the linux script the wrong way.